### PR TITLE
Improve Deezer clone styling

### DIFF
--- a/javascript_dom/projetos/deezer_spotify_clone/favorites.html
+++ b/javascript_dom/projetos/deezer_spotify_clone/favorites.html
@@ -7,11 +7,11 @@
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
-<body class="bg-cyan-900 text-white">
-  <header class="bg-cyan-800 p-4 flex justify-between">
+<body class="bg-gray-900 text-white">
+  <header class="bg-gray-800 p-4 flex justify-between">
     <h1 class="text-xl font-bold flex items-center gap-2"><i class="bi bi-music-note-list"></i>Deezer Clone</h1>
     <nav class="flex gap-4">
-      <a href="home.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-house"></i> Home</a>
+      <a href="home.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-house"></i> Home</a>
       <a href="index.html" class="text-red-400 hover:underline flex items-center gap-1"><i class="bi bi-box-arrow-right"></i> Sair</a>
     </nav>
   </header>

--- a/javascript_dom/projetos/deezer_spotify_clone/home.html
+++ b/javascript_dom/projetos/deezer_spotify_clone/home.html
@@ -7,15 +7,15 @@
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
-<body class="bg-cyan-900 text-white">
-  <header class="bg-cyan-800 p-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+<body class="bg-gray-900 text-white">
+  <header class="bg-gray-800 p-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
     <h1 class="text-xl font-bold flex items-center gap-2"><i class="bi bi-music-note-list"></i>Deezer Clone</h1>
     <form id="searchForm" class="flex gap-2">
       <input id="searchInput" type="text" placeholder="Pesquisar" class="p-1 rounded text-black">
-      <button class="bg-cyan-600 hover:bg-cyan-700 text-white px-2 rounded flex items-center gap-1" type="submit"><i class="bi bi-search"></i> Buscar</button>
+      <button class="bg-green-600 hover:bg-green-700 text-white px-2 rounded flex items-center gap-1" type="submit"><i class="bi bi-search"></i> Buscar</button>
     </form>
     <nav class="flex gap-4">
-      <a href="favorites.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-heart"></i> Favoritos</a>
+      <a href="favorites.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-heart"></i> Favoritos</a>
       <a href="index.html" class="text-red-400 hover:underline flex items-center gap-1"><i class="bi bi-box-arrow-right"></i> Sair</a>
     </nav>
   </header>

--- a/javascript_dom/projetos/deezer_spotify_clone/index.html
+++ b/javascript_dom/projetos/deezer_spotify_clone/index.html
@@ -7,16 +7,16 @@
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
-<body class="bg-cyan-900 flex items-center justify-center min-h-screen text-white">
-  <div class="bg-cyan-800 p-8 rounded w-full max-w-sm">
+<body class="bg-gray-900 flex items-center justify-center min-h-screen text-white">
+  <div class="bg-gray-800 p-8 rounded w-full max-w-sm">
     <h1 class="text-2xl mb-4 text-center flex items-center justify-center gap-2"><i class="bi bi-box-arrow-in-right"></i>Login</h1>
     <form id="loginForm" class="flex flex-col gap-4" onsubmit="validateLogin(event)">
       <input type="email" id="email" placeholder="E-mail" class="p-2 rounded text-black">
       <input type="password" id="password" placeholder="Senha" class="p-2 rounded text-black">
-      <button class="bg-cyan-500 hover:bg-cyan-600 text-white p-2 rounded flex items-center justify-center gap-1" type="submit"><i class="bi bi-box-arrow-in-right"></i> Entrar</button>
+      <button class="bg-green-500 hover:bg-green-600 text-white p-2 rounded flex items-center justify-center gap-1" type="submit"><i class="bi bi-box-arrow-in-right"></i> Entrar</button>
     </form>
     <p class="text-center mt-4">
-      <a href="register.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-person-plus"></i> Criar conta</a>
+      <a href="register.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-person-plus"></i> Criar conta</a>
     </p>
   </div>
   <script src="js/login.js"></script>

--- a/javascript_dom/projetos/deezer_spotify_clone/js/home.js
+++ b/javascript_dom/projetos/deezer_spotify_clone/js/home.js
@@ -3,35 +3,83 @@ function renderTracks(tracks, containerId, removable = false) {
   container.innerHTML = '';
   for (const track of tracks) {
     const div = document.createElement('div');
-    div.className = 'bg-cyan-800 text-white rounded p-4 flex flex-col';
+    const fav = isFavorite(track.id);
+    div.className = 'bg-gray-800 text-white rounded p-4 flex flex-col';
     div.innerHTML = `
       <img src="${track.album.cover_medium}" alt="${track.title}" class="mb-2 rounded">
       <p class="font-semibold">${track.title}</p>
-      <p class="text-sm text-cyan-200">${track.artist.name}</p>
+      <p class="text-sm text-gray-400">${track.artist.name}</p>
       <audio controls class="w-full mt-2" src="${track.preview}"></audio>
-      <button class="mt-2 bg-cyan-200 text-black p-1 rounded favorite-btn flex items-center gap-1">${removable ? '<i class="bi bi-trash"></i> Remover' : '<i class="bi bi-heart"></i> Favoritar'}</button>
+      <button class="mt-2 bg-gray-700 p-1 rounded favorite-btn flex items-center gap-1 ${fav ? 'text-green-500' : ''}">
+        <i class="bi ${fav ? 'bi-heart-fill' : 'bi-heart'}"></i> ${removable ? 'Remover' : 'Favoritar'}
+      </button>
     `;
     const btn = div.querySelector('.favorite-btn');
     btn.addEventListener('click', () => {
-      toggleFavorite(track, removable);
-      if (removable) div.remove();
+      const added = toggleFavorite(track);
+      if (removable && !added) {
+        div.remove();
+        return;
+      }
+      const icon = btn.querySelector('i');
+      if (added) {
+        icon.classList.remove('bi-heart');
+        icon.classList.add('bi-heart-fill');
+        btn.classList.add('text-green-500');
+      } else {
+        icon.classList.add('bi-heart');
+        icon.classList.remove('bi-heart-fill');
+        btn.classList.remove('text-green-500');
+      }
     });
     container.appendChild(div);
   }
 }
 
-function toggleFavorite(track, remove = false) {
-  const key = 'deezerFavorites';
-  const favs = JSON.parse(localStorage.getItem(key)) || [];
-  if (remove) {
-    const updated = favs.filter(t => t.id !== track.id);
-    localStorage.setItem(key, JSON.stringify(updated));
-    return;
+function showSkeletons(containerId, count = 8) {
+  const container = document.getElementById(containerId);
+  container.innerHTML = '';
+  for (let i = 0; i < count; i++) {
+    const sk = document.createElement('div');
+    sk.className = 'animate-pulse bg-gray-800 rounded p-4 flex flex-col space-y-2';
+    sk.innerHTML = `
+      <div class="h-32 bg-gray-700 rounded"></div>
+      <div class="h-4 bg-gray-700 rounded w-3/4"></div>
+      <div class="h-3 bg-gray-700 rounded w-1/2"></div>
+    `;
+    container.appendChild(sk);
   }
-  if (!favs.find(t => t.id === track.id)) {
-    favs.push(track);
-    localStorage.setItem(key, JSON.stringify(favs));
+}
+
+function clearContainer(containerId) {
+  document.getElementById(containerId).innerHTML = '';
+}
+
+const key = 'deezerFavorites';
+
+function getFavorites() {
+  return JSON.parse(localStorage.getItem(key)) || [];
+}
+
+function saveFavorites(favs) {
+  localStorage.setItem(key, JSON.stringify(favs));
+}
+
+function isFavorite(id) {
+  return getFavorites().some(t => t.id === id);
+}
+
+function toggleFavorite(track) {
+  const favs = getFavorites();
+  const idx = favs.findIndex(t => t.id === track.id);
+  if (idx !== -1) {
+    favs.splice(idx, 1);
+    saveFavorites(favs);
+    return false;
   }
+  favs.push(track);
+  saveFavorites(favs);
+  return true;
 }
 
 async function loadGenres() {
@@ -54,11 +102,13 @@ async function loadGenres() {
 
 async function loadTopTracks(genreId = '0') {
   try {
+    showSkeletons('tracks');
     const response = await fetch(`https://api.deezer.com/chart/${genreId}/tracks`);
     const data = await response.json();
     renderTracks(data.data || [], 'tracks');
   } catch (err) {
     console.error(err);
+    clearContainer('tracks');
   }
 }
 

--- a/javascript_dom/projetos/deezer_spotify_clone/js/search.js
+++ b/javascript_dom/projetos/deezer_spotify_clone/js/search.js
@@ -9,11 +9,13 @@ async function searchTracks() {
   title.textContent = `Resultado para: ${query}`;
   if (!query) return;
   try {
+    showSkeletons('results');
     const response = await fetch(`https://api.deezer.com/search?q=${encodeURIComponent(query)}`);
     const data = await response.json();
     renderTracks(data.data || [], 'results');
   } catch (err) {
     console.error(err);
+    clearContainer('results');
   }
 }
 

--- a/javascript_dom/projetos/deezer_spotify_clone/register.html
+++ b/javascript_dom/projetos/deezer_spotify_clone/register.html
@@ -7,17 +7,17 @@
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
-<body class="bg-cyan-900 flex items-center justify-center min-h-screen text-white">
-  <div class="bg-cyan-800 p-8 rounded w-full max-w-sm">
+<body class="bg-gray-900 flex items-center justify-center min-h-screen text-white">
+  <div class="bg-gray-800 p-8 rounded w-full max-w-sm">
     <h1 class="text-2xl mb-4 text-center flex items-center justify-center gap-2"><i class="bi bi-person-plus"></i>Registrar</h1>
     <form id="registerForm" class="flex flex-col gap-4" onsubmit="registerAccount(event)">
       <input type="text" id="name" placeholder="Nome" class="p-2 rounded text-black">
       <input type="email" id="email" placeholder="E-mail" class="p-2 rounded text-black">
       <input type="password" id="password" placeholder="Senha" class="p-2 rounded text-black">
-      <button class="bg-cyan-500 hover:bg-cyan-600 text-white p-2 rounded flex items-center justify-center gap-1" type="submit"><i class="bi bi-person-check"></i> Registrar</button>
+      <button class="bg-green-500 hover:bg-green-600 text-white p-2 rounded flex items-center justify-center gap-1" type="submit"><i class="bi bi-person-check"></i> Registrar</button>
     </form>
     <p class="text-center mt-4">
-      <a href="index.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-arrow-left"></i> Voltar para login</a>
+      <a href="index.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-arrow-left"></i> Voltar para login</a>
     </p>
   </div>
   <script src="js/register.js"></script>

--- a/javascript_dom/projetos/deezer_spotify_clone/search.html
+++ b/javascript_dom/projetos/deezer_spotify_clone/search.html
@@ -7,12 +7,12 @@
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
-<body class="bg-cyan-900 text-white">
-  <header class="bg-cyan-800 p-4 flex justify-between">
+<body class="bg-gray-900 text-white">
+  <header class="bg-gray-800 p-4 flex justify-between">
     <h1 class="text-xl font-bold flex items-center gap-2"><i class="bi bi-music-note-list"></i>Deezer Clone</h1>
     <nav class="flex gap-4">
-      <a href="home.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-house"></i> Home</a>
-      <a href="favorites.html" class="text-cyan-300 hover:underline flex items-center gap-1"><i class="bi bi-heart"></i> Favoritos</a>
+      <a href="home.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-house"></i> Home</a>
+      <a href="favorites.html" class="text-green-400 hover:underline flex items-center gap-1"><i class="bi bi-heart"></i> Favoritos</a>
       <a href="index.html" class="text-red-400 hover:underline flex items-center gap-1"><i class="bi bi-box-arrow-right"></i> Sair</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- restyle pages with a darker Spotify-inspired palette
- add skeleton loading states for API requests
- make favorite button toggle its color and icon

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850d837151c83329be5419cbb30ed8d